### PR TITLE
Refactor error and alert handling in sections and menu items

### DIFF
--- a/src/app/authentication/http-interceptors/auth-interceptor.ts
+++ b/src/app/authentication/http-interceptors/auth-interceptor.ts
@@ -103,8 +103,8 @@ export class AuthInterceptor implements HttpInterceptor {
           this.authService.logout();
           return throwError(() => new Error('Refresh token expired'));
         }
-        // Otros errores de autenticación
-        return throwError(() => new Error('Authentication failed'));
+        // Otros errores HTTP se pasan limpios sin ser envueltos en "Authentication failed"
+        return throwError(() => error);
       })
     );
   }

--- a/src/app/components/navbar/child/navbar-information/navbar-information.component.html
+++ b/src/app/components/navbar/child/navbar-information/navbar-information.component.html
@@ -55,4 +55,4 @@
 		}
 	}
 </nav>
-<p-toast/>
+<app-custom-toast #customToast></app-custom-toast>

--- a/src/app/components/navbar/child/navbar-information/navbar-information.component.ts
+++ b/src/app/components/navbar/child/navbar-information/navbar-information.component.ts
@@ -7,6 +7,8 @@ import { PostService } from '../../../../posts/services/post.service';
 import { NavItem } from '../../../../pages/models/nav-item';
 import { Subject, takeUntil } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
+import { CustomToastComponent } from '../../../../shared/components/custom-toast/custom-toast.component';
+import { ViewChild } from '@angular/core';
 
 @Component({
   selector: 'app-navbar-information',
@@ -30,6 +32,7 @@ export class NavbarInformationComponent implements OnInit, OnChanges, OnDestroy 
   @Input() isMobile: boolean = false;
   @Output() collapse = new EventEmitter<void>(); 
   uuidSectionToEdit: string = '';
+  @ViewChild('customToast') customToast!: CustomToastComponent;
 
   ngOnInit(): void {
     this.isAuthenticated = this.authService.isAuthenticated();
@@ -93,16 +96,39 @@ export class NavbarInformationComponent implements OnInit, OnChanges, OnDestroy 
     this.collapse.emit();
   }
 
-  onCreatedSection(created: Section): void {
-    this.sections.push(created);
+  onCreatedSection(event: {section?: Section, error?: any}): void {
+    if (event.section) {
+      this.sections.push(event.section);
+      this.customToast.showSuccess('Sección creada exitosamente');
+    } else {
+      if (event.error?.status === 409) {
+        this.customToast.showError('Ya existe una sección con esa ruta.');
+      } else {
+        this.customToast.showError('Error al crear sección');
+      }
+    }
   }
 
-  onDeletedSection(deleted: Section): void {
-    this.sections = this.sections.filter(sec => sec.uuid !== deleted.uuid);
+  onDeletedSection(event: {section?: Section, error?: any}): void {
+    if (event.section) {
+      this.sections = this.sections.filter(sec => sec.uuid !== event.section?.uuid);
+      this.customToast.showSuccess('Sección eliminada exitosamente');
+    } else {
+      this.customToast.showError('Error al eliminar sección');
+    }
   }
 
-  onEditSection(edited: Section): void {
-    this.sections = this.sections.map(sec => sec.uuid === edited.uuid ? edited : sec);
+  onEditSection(event: {section?: Section, error?: any}): void {
+    if (event.section) {
+      this.sections = this.sections.map(sec => sec.uuid === event.section?.uuid ? event.section : sec);
+      this.customToast.showSuccess('Sección actualizada exitosamente');
+    } else {
+      if (event.error?.status === 409) {
+        this.customToast.showError('Ya existe una sección con esa ruta.');
+      } else {
+        this.customToast.showError('Error al actualizar sección');
+      }
+    }
   }
 
   hideButtonNewSection(): void {

--- a/src/app/components/navbar/form-section/form-section.component.ts
+++ b/src/app/components/navbar/form-section/form-section.component.ts
@@ -2,7 +2,6 @@ import { Component, ElementRef, EventEmitter, inject, Input, OnChanges, OnDestro
 import { InformationService } from '../../../pages/services/information.service';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { Section } from '../../../pages/models/section';
-import { MessageService } from 'primeng/api';
 import moment from 'moment';
 import { SectionStateService } from '../../../pages/services/sections-state.service';
 import { AuthService } from '../../../authentication/services/auth.service';
@@ -18,7 +17,6 @@ import { HttpErrorResponse } from '@angular/common/http';
 })
 export class FormSectionComponent implements OnInit, OnChanges, OnDestroy {
   private readonly informationService = inject(InformationService);
-  private readonly messageService = inject(MessageService);
   private readonly sectionStateService = inject(SectionStateService);
   private readonly authService = inject(AuthService);
   private readonly route = inject(ActivatedRoute);
@@ -30,9 +28,9 @@ export class FormSectionComponent implements OnInit, OnChanges, OnDestroy {
   @Input() currentNavItem!: NavItem;
   @Output() onCloseNew = new EventEmitter<boolean>();
   @Output() onCloseEdit = new EventEmitter<void>();
-  @Output() onEditedSection = new EventEmitter<Section>();
-  @Output() onDeletedSection = new EventEmitter<Section>();
-  @Output() onCreateSection = new EventEmitter<Section>();
+  @Output() onEditedSection = new EventEmitter<{section?: Section, error?: any}>();
+  @Output() onDeletedSection = new EventEmitter<{section?: Section, error?: any}>();
+  @Output() onCreateSection = new EventEmitter<{section?: Section, error?: any}>();
   @ViewChild('firstInput') firstInput!: ElementRef<HTMLInputElement>;
 
   public isLoading = false;
@@ -96,14 +94,13 @@ export class FormSectionComponent implements OnInit, OnChanges, OnDestroy {
     this.informationService.createSection(newSection).subscribe({
       next: (created) => {
         this.isLoading = false;
-        this.messageService.add({ severity: 'success', summary: 'Exitoso', detail: 'Sección creada exitosamente' });
-        this.onCreateSection.emit(created);
+        this.onCreateSection.emit({section: created});
         this.closeForm();
       },
       error: (error: HttpErrorResponse) => {
         this.isLoading = false;
         console.log('Error al crear seccion', error);
-        this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Error al crear sección' });
+        this.onCreateSection.emit({error});
         this.closeForm();
       }
     })
@@ -124,15 +121,14 @@ export class FormSectionComponent implements OnInit, OnChanges, OnDestroy {
       next: (updated) => {
         this.isLoading = false;
         this.sectionStateService.setSectionToEdit(updated);
-        this.messageService.add({ severity: 'success', summary: 'Exitoso', detail: 'Sección actualizada exitosamente' });
-        this.onEditedSection.emit(updated);
+        this.onEditedSection.emit({section: updated});
         this.handleRedirectionAfterEdit(updated);
         this.closeForm();
       },
       error: (error: HttpErrorResponse) => {
         this.isLoading = false;
         console.log('Error al editar seccion', error);
-        this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Error al actualizar sección' });
+        this.onEditedSection.emit({error});
         this.closeForm();
       }
     })
@@ -154,14 +150,13 @@ export class FormSectionComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private handleDeleteSuccess(): void {
-    this.messageService.add({ severity: 'success', summary: 'Exitoso', detail: 'Sección eliminada exitosamente' });
-    this.onDeletedSection.emit(this.currentSection);
+    this.onDeletedSection.emit({section: this.currentSection});
     this.onCloseEdit.emit();
   }
 
   private handleDeleteError(err: HttpErrorResponse): void {
     console.log('error', err);
-    this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Error al eliminar sección' });
+    this.onDeletedSection.emit({error: err});
     this.onCloseEdit.emit();
   }
 

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -39,4 +39,4 @@
     (onEditedNavItem)="onEditedNavItem($event)"
   ></app-form-menu>
 </p-dialog>
-<p-toast/>
+<app-custom-toast #customToast></app-custom-toast>

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -1,12 +1,12 @@
-import { Component, EventEmitter, inject, OnDestroy, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, inject, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
 import { Subject, takeUntil } from 'rxjs';
 import { NavItem } from '../../pages/models/nav-item';
 import { UserDetail } from '../../posts/models/user-detail';
 import { AuthService } from '../../authentication/services/auth.service';
 import { PostService } from '../../posts/services/post.service';
-import { MessageService } from 'primeng/api';
 import { InformationService } from '../../pages/services/information.service';
 import { ActivatedRoute, Router } from '@angular/router';
+import { CustomToastComponent } from '../../shared/components/custom-toast/custom-toast.component';
 
 @Component({
   selector: 'app-navbar',
@@ -18,9 +18,10 @@ export class NavbarComponent implements OnInit, OnDestroy {
   private readonly informationService = inject(InformationService);
   private readonly authService = inject(AuthService);
   private readonly postService = inject(PostService);
-  private readonly messageService = inject(MessageService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
+
+  @ViewChild('customToast') customToast!: CustomToastComponent;
 
   public isAuthenticated: boolean = false; 
   public currentUser!: UserDetail;
@@ -75,18 +76,26 @@ export class NavbarComponent implements OnInit, OnDestroy {
   onCreatedNavItem(event: { menus?: NavItem[], error?: any }) {
     if(event.menus){
       this.navItems = structuredClone(event.menus).sort((a, b) => a.orderIndex - b.orderIndex);
-      this.messageService.add({ severity: 'success', summary: 'Exitoso', detail: 'Menú creado exitosamente' });
+      this.customToast.showSuccess('Menú creado exitosamente');
     }else{
-      this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Error al crear menú' });
+      if (event.error?.status === 409) {
+        this.customToast.showError('Ya existe un menú con esa ruta.');
+      } else {
+        this.customToast.showError('Error al crear menú');
+      }
     }
   }
 
   onEditedNavItem(event: { menus?: NavItem[], error?: any }) {
     if(event.menus){
       this.navItems = structuredClone(event.menus).sort((a, b) => a.orderIndex - b.orderIndex);
-      this.messageService.add({ severity: 'success', summary: 'Exitoso', detail: 'Menú actualizado exitosamente' });
+      this.customToast.showSuccess('Menú actualizado exitosamente');
     }else{
-      this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Error al actualizar sección' });
+      if (event.error?.status === 409) {
+        this.customToast.showError('Ya existe un menú con esa ruta.');
+      } else {
+        this.customToast.showError('Error al actualizar menú');
+      }
     }
   }
 
@@ -98,9 +107,9 @@ export class NavbarComponent implements OnInit, OnDestroy {
         // Si el nav item eliminado es el que se está visualizando, redirigir al inicio
         this.router.navigate(['/'], { replaceUrl: true });
       }
-      this.messageService.add({ severity: 'success', summary: 'Exitoso', detail: 'Menú eliminado exitosamente' });
+      this.customToast.showSuccess('Menú eliminado exitosamente');
     }else{
-      this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Error al eliminar sección' });
+      this.customToast.showError('Error al eliminar menú');
     }
   }
 


### PR DESCRIPTION
- Fixed the auth-interceptor to allow 409 errors to reach the component.
- Replaced p-toast with app-custom-toast in Navbar and Navbar-Information.
- Delegated the issuance of form-section toasts to their parent component to prevent the alert from being destroyed when the form is closed.