### PR TITLE
Refactor: replace comment config with comments enabled

### DIFF
--- a/src/app/posts/components/comments/comment-list/comment-list.component.html
+++ b/src/app/posts/components/comments/comment-list/comment-list.component.html
@@ -21,7 +21,7 @@
             <span class="mx-1">·</span>
             <ng-container *ngIf="authenticated">
 
-              @if (authenticated && commentConfigId !== '587d7d7f-5g3n-4b77-cf98-77a9h46759d0') {
+              @if (authenticated && commentsEnabled) {
                 <button  class="reply-btn" (click)="toggleReplyInput(comment.uuid)">Responder</button>
               }
 

--- a/src/app/posts/components/comments/comment-list/comment-list.component.ts
+++ b/src/app/posts/components/comments/comment-list/comment-list.component.ts
@@ -21,7 +21,7 @@ export class CommentListComponent implements OnInit, OnChanges, OnDestroy {
   @Input() comments: Comment[] = [];
   @Input() currentUser: UserDetail | null = null;
   @Input() authenticated: boolean = false;
-  @Input() commentConfigId: string = '';
+  @Input() commentsEnabled: boolean = true;
   @Input() postUuid: string = '';
   @Output() onAddReply = new EventEmitter<{ parentUuid: string, replyText: string, isTopLevel: boolean }>();
   @ViewChild('toastRef') private readonly toastRef!: CustomToastComponent;

--- a/src/app/posts/components/comments/comments.component.html
+++ b/src/app/posts/components/comments/comments.component.html
@@ -66,7 +66,7 @@
             [postUuid]="postUuid"
             [currentUser]="currentUser" 
             [authenticated]="authenticated" 
-            [commentConfigId]="post.comment_config_id"
+            [commentsEnabled]="post.commentsEnabled"
             (onAddReply)="handleAddReply($event)">
           </app-comment-list>
         </div>
@@ -74,7 +74,7 @@
     </div>
 
     <!-- Modal Footer -->
-    <div class="modal-footer" *ngIf="authenticated && post.comment_config_id !== '587d7d7f-5g3n-4b77-cf98-77a9h46759d0'">
+    <div class="modal-footer" *ngIf="authenticated && post.commentsEnabled">
       <div class="comment-section d-flex flex-row align-items-center">
         <img *ngIf="currentUser" [src]="currentUser.photo_profile_path || 'assets/default-avatar.png'" alt="Foto de perfil" class="comment-img" />
         <div class="comment-box d-flex align-items-center">

--- a/src/app/posts/components/comments/comments.component.ts
+++ b/src/app/posts/components/comments/comments.component.ts
@@ -146,7 +146,11 @@ export class CommentsComponent implements OnInit, AfterViewInit, OnDestroy {
         }
       },
       error: (err) => {
-        console.error('Error al agregar comentario', err);
+        if (err.status === 403) {
+          console.error('Los comentarios están desactivados en esta publicación');
+        } else {
+          console.error('Error al agregar comentario', err);
+        }
       },
     });
   }

--- a/src/app/posts/components/create-post/create-post.component.html
+++ b/src/app/posts/components/create-post/create-post.component.html
@@ -26,10 +26,12 @@
 						<app-institution-avatar [institution]="institution" size="small"></app-institution-avatar>
 						<div>
 							<p class="fw-bold fs-6">{{ institution.name }}</p>
-							<select id="option-comment" *ngIf="commentConfig" [(ngModel)]="selectedCommentConfig">
-								<option *ngFor="let config of commentConfig" [value]="config.uuid">{{config.name}}
-								</option>
-							</select>
+							<div class="form-check form-switch mt-1">
+								<input class="form-check-input" type="checkbox" id="commentsEnabledSwitch" [(ngModel)]="commentsEnabled">
+								<label class="form-check-label small" for="commentsEnabledSwitch">
+									{{ commentsEnabled ? 'Comentarios activados' : 'Comentarios desactivados' }}
+								</label>
+							</div>
 						</div>
 					}
 				</div>

--- a/src/app/posts/components/create-post/create-post.component.ts
+++ b/src/app/posts/components/create-post/create-post.component.ts
@@ -7,7 +7,6 @@ import { UploadedMedia } from '../../models/uploaded-media';
 import { CreatePost } from '../../models/create-post';
 import { Institution } from '../../models/institution';
 import moment from 'moment';
-import { CommentConfig } from '../../models/comment-config';
 import { TenantService } from '../../../services/tenant.service';
 import { UserDetail } from '../../models/user-detail';
 import imageCompression from 'browser-image-compression';
@@ -24,8 +23,7 @@ export class CreatePostComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly destroy$ = new Subject<void>();
   private modalHiddenListener!: () => void;
   institution!: Institution;
-  commentConfig!: CommentConfig[];
-  selectedCommentConfig!: string;
+  commentsEnabled: boolean = true;
   visibleAreaMedia = signal(false); //Mostrar seleccion y prevista de imagenes
   visibleAreaMediaDoc = signal(false); //Mostrar seleccion y prevista de documentos
   disableLoadImage = signal(false); //Deshabilitar el boton de cargar imagenes
@@ -62,18 +60,6 @@ export class CreatePostComponent implements OnInit, AfterViewInit, OnDestroy {
           console.log(error);
         }
       });
-    //Obtener la configuracion de comentarios
-    this.postService.getCommentsConfiguration()
-      .pipe(takeUntil(this.destroy$))
-      .subscribe({
-        next: (commentsConfiguration: CommentConfig[]) => {
-          this.commentConfig = commentsConfiguration;
-          this.selectedCommentConfig = this.commentConfig[0].uuid;//Por defecto todos comentan
-        },
-        error: (error) => {
-          console.log('Error al obtener la configuracion de comentarios', error)
-        }
-      });
     this.getTypeByRol()
     this.buildForm()
   }
@@ -81,7 +67,7 @@ export class CreatePostComponent implements OnInit, AfterViewInit, OnDestroy {
   ngAfterViewInit(): void {
     this.modalHiddenListener = () => {
       this.visibleModalCreate = false;
-      this.selectedCommentConfig = this.commentConfig[0].uuid;
+      this.commentsEnabled = true;
       this.postForm.get('switchControl')?.setValue(false);
     };
     this.modalCreatePost.nativeElement.addEventListener('hidden.bs.modal', this.modalHiddenListener);
@@ -265,9 +251,8 @@ export class CreatePostComponent implements OnInit, AfterViewInit, OnDestroy {
     const valueFormPost = this.postForm.value;
     const formData = new FormData();
     const post: CreatePost = {
-      institution_id: this.institution.uuid,
       date: moment().format('YYYY-MM-DDTHH:mm:ss.SSS'),
-      comment_config_id: this.selectedCommentConfig,
+      commentsEnabled: this.commentsEnabled,
       post_type: this.currentPostType,
       content: {
         text: valueFormPost.contentPost.trim(),

--- a/src/app/posts/components/modal-edit-post/modal-edit-post.component.html
+++ b/src/app/posts/components/modal-edit-post/modal-edit-post.component.html
@@ -16,9 +16,12 @@
               </app-institution-avatar>
               <div>
                 <p class="fw-bold fs-6">{{ institution.name }}</p>
-                <select id="option-comment" *ngIf="commentConfig" [(ngModel)]="selectedCommentConfig" (ngModelChange)="changedSelectConfigComment()">
-                  <option *ngFor="let config of commentConfig" [value]="config.uuid">{{config.name}}</option>
-                </select>
+                <div class="form-check form-switch mt-1">
+                  <input class="form-check-input" type="checkbox" id="commentsEnabledSwitchEdit" [(ngModel)]="commentsEnabled" (ngModelChange)="onCommentsEnabledChange()">
+                  <label class="form-check-label small" for="commentsEnabledSwitchEdit">
+                    {{ commentsEnabled ? 'Comentarios activados' : 'Comentarios desactivados' }}
+                  </label>
+                </div>
               </div>
             }
           </div>

--- a/src/app/posts/components/modal-edit-post/modal-edit-post.component.ts
+++ b/src/app/posts/components/modal-edit-post/modal-edit-post.component.ts
@@ -2,7 +2,6 @@ import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, signal, View
 import { Subject, takeUntil, concatMap } from 'rxjs';
 import { Institution } from '../../models/institution';
 import { Post } from '../../models/post';
-import { CommentConfig } from '../../models/comment-config';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { PostService } from '../../services/post.service';
 import { Media } from '../../models/media';
@@ -29,8 +28,7 @@ export class ModalEditPostComponent implements OnInit, OnDestroy {
   @Input() showModalEdit!: WritableSignal<boolean>;
   @Output() postUpdatedEvent = new EventEmitter<Post>();
   public isLoading = false;
-  public commentConfig!: CommentConfig[];
-  public selectedCommentConfig!: string;
+  public commentsEnabled: boolean = true;
   public maxLegthTextPost = 1200;
   public visibleAreaMedia = signal(false); //Mostrar seleccion y prevista de imagenes
   public visibleAreaMediaDoc = signal(false); //Mostrar seleccion y prevista de documentos
@@ -63,18 +61,7 @@ export class ModalEditPostComponent implements OnInit, OnDestroy {
         this.disableLoadImage.set(true) :
         this.disableLoadDoc.set(true)
     }
-    //Obtener la configuracion de comentarios
-    this.postService.getCommentsConfiguration()
-      .pipe(takeUntil(this.destroy$))
-      .subscribe({
-        next: (commentsConfiguration: CommentConfig[])=>{
-          this.commentConfig = commentsConfiguration;
-          this.selectedCommentConfig = this.postToEdit.comment_config_id;//Configuracion de comentarios del post
-        },
-        error: (error)=>{
-          console.log('Error al obtener la configuracion de comentarios', error)
-        }
-      });
+    this.commentsEnabled = this.postToEdit.commentsEnabled ?? true;
     this.getTypeByRol()
     this.buildForm()
     
@@ -164,15 +151,16 @@ export class ModalEditPostComponent implements OnInit, OnDestroy {
 
   private checkDisableSaveButton(){
     const textPost: string = this.postForm.get('contentPost')?.value ?? '';
-    if((textPost === '' || textPost.length > this.maxLegthTextPost) && (this.listNewMediaFile.length === 0 
-      && this.listOldMediaFile.length === 0 && !this.fileNewDoc)){
+    const commentsEnabledChanged = this.commentsEnabled !== (this.postToEdit.commentsEnabled ?? true);
+    if((textPost === '' || textPost.length > this.maxLegthTextPost) && (this.listNewMediaFile.length === 0
+      && this.listOldMediaFile.length === 0 && !this.fileNewDoc) && !commentsEnabledChanged){
       this.disabledSaveButton.set(true);
     }else{
       this.disabledSaveButton.set(false);
     }
   }
 
-  public changedSelectConfigComment(): void {
+  public onCommentsEnabledChange(): void {
     this.checkDisableSaveButton();
   }
 
@@ -182,7 +170,7 @@ export class ModalEditPostComponent implements OnInit, OnDestroy {
     if (modalElement) {
       let modal = Modal.getInstance(modalElement);
       modal?.hide();
-      this.selectedCommentConfig = this.postToEdit.comment_config_id;
+      this.commentsEnabled = this.postToEdit.commentsEnabled ?? true;
       this.showModalEdit.set(false);
       this.listNewMediaFile = [];
       this.fileNewDoc = null;
@@ -296,9 +284,8 @@ export class ModalEditPostComponent implements OnInit, OnDestroy {
     const responseMedia: Media[] = []; //Respuesta de imagenes y videos guardados
     let responseDoc: Media;
     const editedPost: CreatePost = {
-      institution_id: this.institution.uuid,
       date: this.postToEdit.date,
-      comment_config_id: this.selectedCommentConfig,
+      commentsEnabled: this.commentsEnabled,
       post_type: this.currentPostType,
       content: {
         text: valueFormPost.contentPost,

--- a/src/app/posts/components/post/post.component.html
+++ b/src/app/posts/components/post/post.component.html
@@ -123,7 +123,7 @@
 			</div>
 		</button>
 		<!-- Boton de Comentar -->
-		@if(post.comment_config_id !== '587d7d7f-5g3n-4b77-cf98-77a9h46759d0'){
+		@if(post.commentsEnabled){
 			<button type="button" class="btn icon-btn" id="btn-comment" (click)="openViewPostComments(post)">
 				<i class="bi bi-chat-left-text"></i>
 				Comentar</button>

--- a/src/app/posts/models/create-post.ts
+++ b/src/app/posts/models/create-post.ts
@@ -1,10 +1,9 @@
 import { Content } from "./content";
 
 export interface CreatePost {
-    institution_id:    string;
-    date:              string;
-    comment_config_id: string;
-    post_type: string;
-    content:           Content;
-    fb_post_enable: boolean;
+    date:             string;
+    commentsEnabled?: boolean;
+    post_type:        string;
+    content:          Content;
+    fb_post_enable:   boolean;
 }

--- a/src/app/posts/models/post.ts
+++ b/src/app/posts/models/post.ts
@@ -8,7 +8,7 @@ export interface Post {
     user_id:           string;
     name?:             string;
     lastName?:         string;
-    comment_config_id: string;
+    commentsEnabled:   boolean;
     post_type: string;
     date:              string;
     content:           Content;

--- a/src/app/posts/services/post.service.ts
+++ b/src/app/posts/services/post.service.ts
@@ -9,7 +9,6 @@ import { Comment } from '../models/comment';
 import { UploadedMedia } from '../models/uploaded-media';
 import { CreateReaction } from '../models/create-reaction';
 import { environment } from '../../../environments/environment';
-import { CommentConfig } from '../models/comment-config';
 import { map } from 'rxjs/operators';
 import { EmojiType } from '../models/emoji-type';
 import { UserDetail } from '../models/user-detail';
@@ -148,12 +147,6 @@ export class PostService {
 
   }
 
-
-  //Método para obtener configuraciones de comentarios
-  getCommentsConfiguration(): Observable<CommentConfig[]> {
-    const commentConfigUrl = 'comment-config'
-    return this.http.get<CommentConfig[]>(`${this.ROOT_URL}/${commentConfigUrl}`);
-  }
 
   //Método para eliminar un post
   deletePost(postUuid: string): Observable<Post> {


### PR DESCRIPTION
 refactor: replace comment_config_id with commentsEnabled boolean

  Remove deprecated comment-config API calls and replace UUID-based
  comment control with a commentsEnabled boolean field across post
  creation, editing, and display. Handle 403 on comment submission.
